### PR TITLE
Add github workflows for building Docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+
+name: Build image
+
+on: push
+
+jobs:
+  build:
+    name: Build Docker images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build
+        uses: docker/build-push-action@v3
+        with:
+          push: false

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+    # Maintain dependencies for GitHub Actions
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+        interval: "daily"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Build and publish Docker image
+
+on:
+  push:
+    branches: ['main']
+
+concurrency:
+  # limit invocations of this workflow to one at a time to prevent race
+  # conditions
+  group: build-docker
+  # just canceling could lead to side-effects of incomplete runs, so let's just
+  # run through each invocation completely
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build and publish Docker images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64,darwin
+          push: true
+          tags:
+            - "gcr.io/hoprassociation/hopr-rpc-relay:${{ github.sha }}"

--- a/.github/workflows/publish_tagged.yml
+++ b/.github/workflows/publish_tagged.yml
@@ -1,0 +1,29 @@
+name: Build and publish tagged Docker image
+
+on:
+  push:
+    tags: ['v**']
+
+concurrency:
+  # limit invocations of this workflow to one at a time to prevent race
+  # conditions
+  group: build-tagged-docker
+  # just canceling could lead to side-effects of incomplete runs, so let's just
+  # run through each invocation completely
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build and publish tagged Docker images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64,darwin
+          push: true
+          tags:
+            - "gcr.io/hoprassociation/hopr-rpc-relay:${{ github.ref_name }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 build
+devkit


### PR DESCRIPTION
This will build images on every push (PR), publish images by SHA for PR merges to branch `main` and publish images by version tag when a Git tag is pushed. The assumption is, that the author makes sure the version in `package.json` is updated as well. No checks are done.